### PR TITLE
Bump meshctl upgrade timeout

### DIFF
--- a/changelog/v0.4.6/bump-upgrade-timeout.yaml
+++ b/changelog/v0.4.6/bump-upgrade-timeout.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Bump the timeout on meshctl upgrade, which was too restrictive before.
+    issueLink: https://github.com/solo-io/service-mesh-hub/issues/506

--- a/cli/pkg/tree/upgrade/assets/helpers.go
+++ b/cli/pkg/tree/upgrade/assets/helpers.go
@@ -28,7 +28,7 @@ func MeshctlBinaryName() string {
 
 //go:generate mockgen -destination ./mocks/helpers.go -source ./helpers.go
 var (
-	DefaultRequestTimeout = 5 * time.Second
+	DefaultRequestTimeout = 15 * time.Second
 
 	NoReleaseContainingAssetError = eris.New("couldn't find any release with the desired asset")
 )


### PR DESCRIPTION

BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/issues/506