### PR TITLE
Fix panic from mesh-networking when ACP references nonexistent cluster

### DIFF
--- a/changelog/v0.4.7/panic-fix.yaml
+++ b/changelog/v0.4.7/panic-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Fix panic in mesh-networking when an ACP selector references a nonexistent cluster
+  issueLink: https://github.com/solo-io/service-mesh-hub/issues/580

--- a/services/mesh-networking/pkg/access/access-control-policy-translator/istio-translator/istio_translator_test.go
+++ b/services/mesh-networking/pkg/access/access-control-policy-translator/istio-translator/istio_translator_test.go
@@ -507,6 +507,24 @@ var _ = Describe("IstioTranslator", func() {
 		Expect(translatorError).To(BeNil())
 	})
 
+	It("should error if a service account ref doesn't match a real service account", func() {
+		testData := initTestData()
+		fakeRef := &core_types.ResourceRef{
+			Name:      "name1",
+			Namespace: "namespace1",
+			Cluster:   "fake-cluster-name",
+		}
+		testData.accessControlPolicy.Spec.SourceSelector = &core_types.IdentitySelector{
+			IdentitySelectorType: &core_types.IdentitySelector_ServiceAccountRefs_{
+				ServiceAccountRefs: &core_types.IdentitySelector_ServiceAccountRefs{
+					ServiceAccounts: []*core_types.ResourceRef{fakeRef},
+				},
+			},
+		}
+		translatorError := istioTranslator.Translate(ctx, testData.targetServices, testData.accessControlPolicy)
+		Expect(translatorError.ErrorMessage).To(ContainSubstring(istio_translator.ServiceAccountRefNonexistent(fakeRef).Error()))
+	})
+
 	It("should return ACP processing error", func() {
 		acp := &networking_v1alpha1.AccessControlPolicy{
 			Spec: networking_types.AccessControlPolicySpec{


### PR DESCRIPTION

BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/issues/580