### PR TITLE
Reduce released CLI binary size by 75%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ $(OUTPUT_DIR)/meshctl-darwin-amd64: $(SOURCES)
 $(OUTPUT_DIR)/meshctl-windows-amd64.exe: $(SOURCES)
 	$(GO_BUILD_FLAGS) GOOS=windows go build -ldflags=$(LDFLAGS) -gcflags=$(GCFLAGS) -o $@ $(CLI_DIR)/cmd/main.go
 
+# https://upx.github.io/
 pack-cli:
 	upx $(OUTPUT_DIR)/meshctl*
 

--- a/changelog/v0.4.11/binary-size.yaml
+++ b/changelog/v0.4.11/binary-size.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NEW_FEATURE
-    description: Reduce CLI binary size by 75%
-    issueLink: https://github.com/solo-io/service-mesh-hub/issues/651

--- a/changelog/v0.4.11/binary-size.yaml
+++ b/changelog/v0.4.11/binary-size.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Reduce CLI binary size by
+    issueLink: https://github.com/solo-io/service-mesh-hub/issues/651

--- a/changelog/v0.4.11/binary-size.yaml
+++ b/changelog/v0.4.11/binary-size.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: NEW_FEATURE
-    description: Reduce CLI binary size by
+    description: Reduce CLI binary size by 75%
     issueLink: https://github.com/solo-io/service-mesh-hub/issues/651

--- a/changelog/v0.4.12/binary-size.yaml
+++ b/changelog/v0.4.12/binary-size.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Reduce CLI binary size by 75%
+    issueLink: https://github.com/solo-io/service-mesh-hub/issues/651


### PR DESCRIPTION
TODO: Bump go-mod-make version number
BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/issues/651