### PR TITLE
Fix hyphens on helm install command

### DIFF
--- a/docs/content/setup/_index.md
+++ b/docs/content/setup/_index.md
@@ -123,7 +123,7 @@ Note that the location of the Service Mesh Hub Helm charts is subject to change.
 Then install Service Mesh Hub into the `service-mesh-hub` namespace:
 
 ```shell
-helm install smh smh/service-mesh-hub —-namespace service-mesh-hub
+helm install smh smh/service-mesh-hub --namespace service-mesh-hub
 ```
 
 ### Verify install


### PR DESCRIPTION
Helm command had the wrong hyphen/dash and was giving error: 
```
Error: expected at most two arguments, unexpected arguments: —-namespace, service-mesh-hub
```

Traced to dash in place of hyphen, shown with hexdump (top was copied from docs, bottom is me inputting two hyphens)

```bash
❯ echo —- | hexdump
0000000 e2 80 94 2d 0a
0000005
❯ echo -- | hexdump
0000000 2d 2d 0a
0000003
```