### PR TITLE
Add nodeSelector to mesh-discovery and mesh-networking helm template

### DIFF
--- a/changelog/v0.4.12/helm-nodeSelector.yaml
+++ b/changelog/v0.4.12/helm-nodeSelector.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Add nodeSelector for mesh-discovery and mesh-networking helm templates
+    issueLink: https://github.com/solo-io/service-mesh-hub/pull/715

--- a/changelog/v0.4.12/helm-nodeSelector.yaml
+++ b/changelog/v0.4.12/helm-nodeSelector.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: NEW_FEATURE
-    description: Add nodeSelector for mesh-discovery and mesh-networking helm templates
+    description: Add nodeSelector for mesh-discovery, mesh-networking, and csr-agent helm templates
     issueLink: https://github.com/solo-io/service-mesh-hub/pull/715

--- a/install/helm/charts/csr-agent/templates/deployment.yaml
+++ b/install/helm/charts/csr-agent/templates/deployment.yaml
@@ -36,3 +36,7 @@ spec:
             - name: START_STATS_SERVER
               value: "true"
             {{- end}}
+    {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+    {{- end }}

--- a/install/helm/charts/csr-agent/values-template.yaml
+++ b/install/helm/charts/csr-agent/values-template.yaml
@@ -6,4 +6,5 @@ deployment:
     pullPolicy: IfNotPresent
   stats:
     enabled: true
+  nodeSelector: {}
 global: {}

--- a/install/helm/charts/management-plane/values-template.yaml
+++ b/install/helm/charts/management-plane/values-template.yaml
@@ -4,3 +4,9 @@ global:
     pullPolicy: IfNotPresent
   stats:
     enabled: true
+mesh-discovery:
+  deployment:
+    nodeSelector: {}
+mesh-networking:
+  deployment:
+    nodeSelector: {}

--- a/install/helm/charts/mesh-discovery/templates/deployment.yaml
+++ b/install/helm/charts/mesh-discovery/templates/deployment.yaml
@@ -36,3 +36,7 @@ spec:
             - name: START_STATS_SERVER
               value: "true"
             {{- end}}
+    {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+    {{- end }}

--- a/install/helm/charts/mesh-discovery/values-template.yaml
+++ b/install/helm/charts/mesh-discovery/values-template.yaml
@@ -6,3 +6,4 @@ deployment:
     pullPolicy: IfNotPresent
   stats:
     enabled: true
+  nodeSelector: {}

--- a/install/helm/charts/mesh-networking/templates/deployment.yaml
+++ b/install/helm/charts/mesh-networking/templates/deployment.yaml
@@ -36,3 +36,7 @@ spec:
             - name: START_STATS_SERVER
               value: "true"
             {{- end}}
+    {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+    {{- end }}

--- a/install/helm/charts/mesh-networking/values-template.yaml
+++ b/install/helm/charts/mesh-networking/values-template.yaml
@@ -6,3 +6,4 @@ deployment:
     pullPolicy: IfNotPresent
   stats:
     enabled: true
+  nodeSelector: {}


### PR DESCRIPTION
Allow for a nodeSelector to the mesh-discovery and mesh-networking templates (used in service-mesh-hub).

For example, to specify the os and arch in the template, add the following to **values.yaml**:
```yaml
mesh-discovery:
  deployment:
    nodeSelector:
      kubernetes.io/os: linux
      kubernetes.io/arch: amd64
mesh-networking:
  deployment:
    nodeSelector:
      kubernetes.io/os: linux
      kubernetes.io/arch: amd64
```

Alternatively, specify by passing values using `--set` in CLI command:

```
helm install smh smh/service-mesh-hub \
  --namespace service-mesh-hub \
  --set "mesh-discovery.nodeSelector.kubernetes\.io/os=linux" \
  --set "mesh-discovery.nodeSelector.kubernetes\.io/arch=amd64" \
  --set "mesh-networking.nodeSelector.kubernetes\.io/os=linux" \
  --set "mesh-networking.nodeSelector.kubernetes\.io/arch=amd64"
```

### Justification

If you have a mixed architecture cluster (such as amd64 and arm64/aarch64 architecture-based instances) and need Service Mesh Hub to launch on the amd64 instances.
BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/pull/715