### PR TITLE
Fix ttlDays casting (#725)

### DIFF
--- a/changelog/v0.4.12/fix-ttldate-cast.yaml
+++ b/changelog/v0.4.12/fix-ttldate-cast.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix casting ttlDays in virtual_mesh_printer.go with strconv.Itoa
+    issueLink: https://github.com/solo-io/service-mesh-hub/issues/725

--- a/cli/pkg/common/table_printing/test_goldens/virtual_mesh/virtual_mesh.golden
+++ b/cli/pkg/common/table_printing/test_goldens/virtual_mesh/virtual_mesh.golden
@@ -6,7 +6,7 @@
 | Display Name: my favorite virtual mesh      | - mesh-3                 | Certificate Authority:                   |   Message: This is a conflict         |
 |                                             |                          |   Type: Self Signed                      |                                       |
 |                                             |                          |   Org Name: my-org                       | Config Status:                        |
-|                                             |                          |   TTL: ŭ days                            |   State: ACCEPTED                     |
+|                                             |                          |   TTL: 365 days                          |   State: ACCEPTED                     |
 |                                             |                          |   Key Size: 2048                         |                                       |
 |                                             |                          |                                          |                                       |
 |                                             |                          | Federation Mode: PERMISSIVE              |                                       |

--- a/cli/pkg/common/table_printing/virtual_mesh_printer.go
+++ b/cli/pkg/common/table_printing/virtual_mesh_printer.go
@@ -3,6 +3,7 @@ package table_printing
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/solo-io/service-mesh-hub/cli/pkg/common/table_printing/internal"
@@ -115,7 +116,7 @@ func (m *virtualMeshPrinter) buildConfigCell(
 			orgName = certType.Builtin.GetOrgName()
 		}
 		items = append(items, fmt.Sprintf("  Org Name: %s", orgName))
-		ttlDays := string(int(certgen.DefaultRootCertTTLDays))
+		ttlDays := strconv.Itoa(certgen.DefaultRootCertTTLDays)
 		if certType.Builtin.GetTtlDays() != 0 {
 			ttlDays = string(certType.Builtin.GetTtlDays())
 		}


### PR DESCRIPTION
Fix #725 
* Fix casting ttlDays in virtual_mesh_printer.go with strconv.Itoa
BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/issues/725