### PR TITLE
minor CLI fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifeq ($(TAGGED_VERSION),)
 endif
 VERSION ?= $(shell echo $(TAGGED_VERSION) | cut -c 2-)
 
-LDFLAGS := "-X github.com/solo-io/service-mesh-hub/pkg/common/version.Version=$(VERSION)"
+LDFLAGS := "-X github.com/solo-io/service-mesh-hub/pkg/common/container-runtime/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64

--- a/changelog/v0.6.1/fix-demo-cmd.yaml
+++ b/changelog/v0.6.1/fix-demo-cmd.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix copy for istio multicluster demo cmd.
+    issueLink: https://github.com/solo-io/service-mesh-hub/issues/823

--- a/cli/pkg/tree/demo/istio-multicluster/cleanup_cmd.go
+++ b/cli/pkg/tree/demo/istio-multicluster/cleanup_cmd.go
@@ -14,9 +14,9 @@ func Cleanup(
 	opts *options.Options,
 ) CleanupCmd {
 	init := &cobra.Command{
-		Use:   cliconstants.AppmeshEksCleanupCommand.Use,
-		Short: cliconstants.AppmeshEksCleanupCommand.Short,
-		Long:  cliconstants.AppmeshEksCleanupCommand.Long,
+		Use:   cliconstants.IstioMulticlusterCleanupCommand.Use,
+		Short: cliconstants.IstioMulticlusterCleanupCommand.Short,
+		Long:  cliconstants.IstioMulticlusterCleanupCommand.Long,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return istioMulticlusterCleanup(runner)
 		},

--- a/cli/pkg/tree/demo/istio-multicluster/init_cmd.go
+++ b/cli/pkg/tree/demo/istio-multicluster/init_cmd.go
@@ -20,9 +20,9 @@ func Init(
 	runner exec.Runner,
 ) InitCmd {
 	init := &cobra.Command{
-		Use:   cliconstants.AppmeshEksInitCommand.Use,
-		Short: cliconstants.AppmeshEksInitCommand.Short,
-		Long:  cliconstants.AppmeshEksInitCommand.Long,
+		Use:   cliconstants.IstioMulticlusterInitCommand.Use,
+		Short: cliconstants.IstioMulticlusterInitCommand.Short,
+		Long:  cliconstants.IstioMulticlusterInitCommand.Long,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return istioMulticlusterDemo(runner)
 		},

--- a/docs/content/reference/cli/meshctl_demo_istio-multicluster.md
+++ b/docs/content/reference/cli/meshctl_demo_istio-multicluster.md
@@ -33,6 +33,6 @@ meshctl demo istio-multicluster [flags]
 ### SEE ALSO
 
 * [meshctl demo](../meshctl_demo)	 - Command line utilities for running/interacting with Service Mesh Hub demos
-* [meshctl demo istio-multicluster cleanup](../meshctl_demo_istio-multicluster_cleanup)	 - Cleanup bootstrapped resources AWS Appmesh and EKS resources
-* [meshctl demo istio-multicluster init](../meshctl_demo_istio-multicluster_init)	 - Bootstrap an AWS App mesh and EKS cluster demo with Service Mesh Hub
+* [meshctl demo istio-multicluster cleanup](../meshctl_demo_istio-multicluster_cleanup)	 - Cleanup bootstrapped local resources.
+* [meshctl demo istio-multicluster init](../meshctl_demo_istio-multicluster_init)	 - Bootstrap a multicluster Istio demo with Service Mesh Hub.
 

--- a/docs/content/reference/cli/meshctl_demo_istio-multicluster_cleanup.md
+++ b/docs/content/reference/cli/meshctl_demo_istio-multicluster_cleanup.md
@@ -4,11 +4,11 @@ weight: 5
 ---
 ## meshctl demo istio-multicluster cleanup
 
-Cleanup bootstrapped resources AWS Appmesh and EKS resources
+Cleanup bootstrapped local resources.
 
 ### Synopsis
 
-Cleanup bootstrapped resources AWS Appmesh and EKS resources
+Cleanup bootstrapped local resources.
 
 ```
 meshctl demo istio-multicluster cleanup [flags]

--- a/docs/content/reference/cli/meshctl_demo_istio-multicluster_init.md
+++ b/docs/content/reference/cli/meshctl_demo_istio-multicluster_init.md
@@ -4,19 +4,11 @@ weight: 5
 ---
 ## meshctl demo istio-multicluster init
 
-Bootstrap an AWS App mesh and EKS cluster demo with Service Mesh Hub
+Bootstrap a multicluster Istio demo with Service Mesh Hub.
 
 ### Synopsis
 
-
-Prerequisites:
-	1. meshctl
-	2. eksctl (https://github.com/weaveworks/eksctl)
-	3. Helm (https://helm.sh/docs/intro/install/)
-	4. AWS API credentials must be configured, either through the "~/.aws/credentials" file or environment variables. See these references for more information:
-         a. https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
-         b. https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html
-
+Running the Service Mesh Hub demo setup locally requires 4 tools to be installed, and accessible via the PATH. meshctl, kubectl, docker, and kind. This command will bootstrap 2 clusters, one of which will run the Service Mesh Hub management-plane as well as Istio, and the other will just run Istio.
 
 ```
 meshctl demo istio-multicluster init [flags]


### PR DESCRIPTION
- Update destination package for setting image version via the linker.
- Fix for istio-multicluster demo copy.

Before (CLI v0.6.0):
```shell
⛵ kind-local in service-mesh-hub on  fix-demo-desc via 🐹 v1.14
❯ meshctl version
Client: {"version":"undefined"}
Server: version undefined, could not find any version of service mesh hub running

⛵ kind-local in service-mesh-hub on  fix-demo-desc via 🐹 v1.14
❯ meshctl demo istio-multicluster --help
Demo Service Mesh Hub functionality with two Istio control planes deployed on separate clusters.

Usage:
  meshctl demo istio-multicluster [flags]
  meshctl demo istio-multicluster [command]

Available Commands:
  cleanup     Cleanup bootstrapped resources AWS Appmesh and EKS resources
  init        Bootstrap an AWS App mesh and EKS cluster demo with Service Mesh Hub
```

After (built with this change in progress):
```shell
⛵ kind-local in service-mesh-hub on  fix-demo-desc [!] via 🐹 v1.14
❯ _output/meshctl-darwin-amd64 version
Client: {"version":"0.6.0-2-g21350e5c-dirty"}
Server: version undefined, could not find any version of service mesh hub running

⛵ kind-local in service-mesh-hub on  fix-demo-desc [!] via 🐹 v1.14
❯ _output/meshctl-darwin-amd64 demo istio-multicluster --help
Demo Service Mesh Hub functionality with two Istio control planes deployed on separate clusters.

Usage:
  meshctl demo istio-multicluster [flags]
  meshctl demo istio-multicluster [command]

Available Commands:
  cleanup     Cleanup bootstrapped local resources.
  init        Bootstrap a multicluster Istio demo with Service Mesh Hub.
```
BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/issues/823