### PR TITLE
Fix FailoverService translated EnvoyFilter local FQDN cluster string

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -68,7 +68,7 @@ jobs:
         istioctl-binary: [
           'https://github.com/istio/istio/releases/download/1.5.2/istio-1.5.2-linux.tar.gz',
           'https://github.com/istio/istio/releases/download/1.6.8/istio-1.6.8-linux-amd64.tar.gz',
-          'https://github.com/istio/istio/releases/download/1.7.0-rc.1/istio-1.7.0-rc.1-linux-amd64.tar.gz',
+          'https://github.com/istio/istio/releases/download/1.7.0/istio-1.7.0-linux-amd64.tar.gz',
         ]
     steps:
       - uses: actions/checkout@v2

--- a/changelog/v0.7.3/failover-service-envoy-filter-fix.yaml
+++ b/changelog/v0.7.3/failover-service-envoy-filter-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix EnvoyFilter incorrect cluster string when translated for local k8s service.
+    issueLink: https://github.com/solo-io/service-mesh-hub/issues/933

--- a/pkg/mesh-networking/translation/istio/mesh/failoverservice/failover_service_translator.go
+++ b/pkg/mesh-networking/translation/istio/mesh/failoverservice/failover_service_translator.go
@@ -347,7 +347,7 @@ func (t *translator) buildEnvoyAggregateClusterConfig(
 			var hostname string
 			if kubeService.Ref.ClusterName == failoverServiceClusterName {
 				// Local k8s DNS
-				hostname = t.clusterDomains.GetServiceLocalFQDN(trafficTarget)
+				hostname = t.clusterDomains.GetServiceLocalFQDN(kubeService.Ref)
 			} else {
 				// Multicluster global DNS
 				hostname = t.clusterDomains.GetServiceGlobalFQDN(kubeService.Ref)

--- a/pkg/mesh-networking/translation/istio/mesh/failoverservice/failover_service_translator_test.go
+++ b/pkg/mesh-networking/translation/istio/mesh/failoverservice/failover_service_translator_test.go
@@ -194,8 +194,9 @@ var _ = Describe("FailoverServiceTranslator", func() {
 		}, failoverService.Spec).Return(nil)
 
 		for _, trafficTarget := range allTrafficTargets {
-			mockClusterDomainRegistry.EXPECT().GetServiceLocalFQDN(trafficTarget).Return(trafficTarget.Name + "." + trafficTarget.Namespace)
-			mockClusterDomainRegistry.EXPECT().GetServiceGlobalFQDN(trafficTarget.Spec.GetKubeService().Ref).Return(trafficTarget.Name + "." + trafficTarget.Namespace + ".global")
+			kubeService := trafficTarget.Spec.GetKubeService()
+			mockClusterDomainRegistry.EXPECT().GetServiceLocalFQDN(kubeService.Ref).Return(trafficTarget.Name + "." + trafficTarget.Namespace)
+			mockClusterDomainRegistry.EXPECT().GetServiceGlobalFQDN(kubeService.Ref).Return(trafficTarget.Name + "." + trafficTarget.Namespace + ".global")
 		}
 
 		outputs := istio.NewBuilder(context.TODO(), "")

--- a/test/e2e/istio/failover_service_test.go
+++ b/test/e2e/istio/failover_service_test.go
@@ -183,6 +183,8 @@ var _ = Describe("FailoverService", func() {
 			Expect(err).NotTo(HaveOccurred())
 			utils.AssertTrafficPolicyStatuses(dynamicClient, BookinfoNamespace)
 
+			// first check that we have a response to reduce flakiness
+			Eventually(curlReviews, "1m", "1s").Should(ContainSubstring(`"color": "red"`))
 			Consistently(curlReviews, "5s", "0.2s").Should(ContainSubstring(`"color": "red"`))
 		})
 

--- a/test/e2e/istio/failover_service_test.go
+++ b/test/e2e/istio/failover_service_test.go
@@ -183,9 +183,8 @@ var _ = Describe("FailoverService", func() {
 			Expect(err).NotTo(HaveOccurred())
 			utils.AssertTrafficPolicyStatuses(dynamicClient, BookinfoNamespace)
 
-			// first check that we have a response to reduce flakiness
+			// reviews-v3 is only deployed on remote cluster, so receiving a response proves that the FailoverService is working
 			Eventually(curlReviews, "1m", "1s").Should(ContainSubstring(`"color": "red"`))
-			Consistently(curlReviews, "5s", "0.2s").Should(ContainSubstring(`"color": "red"`))
 		})
 
 		By("re-enable management-plane reviews deployments", func() {


### PR DESCRIPTION

BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/issues/933