### PR TITLE
Older docs version warning

### DIFF
--- a/changelog/v0.9.2/previous-version-warning.yaml
+++ b/changelog/v0.9.2/previous-version-warning.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/service-mesh-hub/issues/1051
+    description: Add a notice to older versions of the docs site
+    resolvesIssue: true

--- a/docs/layouts/partials/versionnavigation.html
+++ b/docs/layouts/partials/versionnavigation.html
@@ -1,3 +1,6 @@
+{{ if ne $.Site.Data.Solo.LatestVersion $.Site.Data.Solo.DocsVersion }}
+  <div sytle="margin-right:5em;"><mark>You are viewing a previous version of Service Mesh Hub. Select latest from the drop-down menu. </mark></div>
+{{ end }}
 <label for="version-selection" id="version-selection-label">Version:</label>
 <select id="version-selection" onchange="javascript:location.href = this.value;">
   {{- range $version := .Site.Data.Solo.DocsVersions}}

--- a/docs/layouts/partials/versionnavigation.html
+++ b/docs/layouts/partials/versionnavigation.html
@@ -1,4 +1,4 @@
-{{ if ne $.Site.Data.Solo.LatestVersion $.Site.Data.Solo.DocsVersion }}
+{{ if ne "latest" (strings.TrimPrefix "/service-mesh-hub/" $.Site.Data.Solo.DocsVersion) }}
   <div sytle="margin-right:5em;"><mark>You are viewing a previous version of Service Mesh Hub. Select latest from the drop-down menu. </mark></div>
 {{ end }}
 <label for="version-selection" id="version-selection-label">Version:</label>


### PR DESCRIPTION
Add a notice in the header of previous versions of the docs. Per issue #1051 

Please verify the logic in the Hugo template, it's hard to test this change locally since the generation process for the site is quite different for the Solo.yaml file.
BOT NOTES: 
resolves https://github.com/solo-io/service-mesh-hub/issues/1051